### PR TITLE
About 페이지 building.png 이미지에 rounded-xl 스타일 추가

### DIFF
--- a/features/about/ui/AboutSeoulOffice.tsx
+++ b/features/about/ui/AboutSeoulOffice.tsx
@@ -20,7 +20,7 @@ export function AboutSeoulOffice({ dict }: AboutSeoulOfficeProps) {
           alt={dict.about.seoulOffice.title}
           width={335}
           height={446}
-          className='w-full object-contain'
+          className='w-full object-contain rounded-xl'
           priority
         />
       </div>


### PR DESCRIPTION
About 페이지의 K-DOC 서울지사 building.png 이미지에 rounded-xl 스타일을 추가하여 모서리를 둥글게 처리했습니다.