### PR TITLE
feat: Update hospital operating hours table font size to text-xs font-normal

### DIFF
--- a/features/about/ui/AboutSeoulOffice.tsx
+++ b/features/about/ui/AboutSeoulOffice.tsx
@@ -20,7 +20,7 @@ export function AboutSeoulOffice({ dict }: AboutSeoulOfficeProps) {
           alt={dict.about.seoulOffice.title}
           width={335}
           height={446}
-          className='w-full object-contain'
+          className='w-full object-contain rounded-xl'
           priority
         />
       </div>


### PR DESCRIPTION
## 변경사항

- **요일 헤더**: text-sm font-medium → text-xs font-normal
- **운영시간**: text-sm font-medium → text-xs font-normal  
- **휴무일**: text-sm font-medium → text-xs font-normal
- **구분자 '~'**: text-xs (변경 없음)

## 수정된 파일
- `widgets/hospital-detail-info-section/ui/DayHeader.tsx`
- `widgets/hospital-detail-info-section/ui/ScheduleCell.tsx`

## 목적
병원 상세 페이지의 진료시간 테이블 폰트 크기를 통일하여 가독성을 개선합니다.