### PR TITLE
feat: Update hospital operating hours table font size to text-xs font-normal

### DIFF
--- a/widgets/hospital-detail-info-section/ui/DayHeader.tsx
+++ b/widgets/hospital-detail-info-section/ui/DayHeader.tsx
@@ -9,7 +9,7 @@ export function DayHeader({ day, dayIndex, isHoliday }: DayHeaderProps) {
         isHoliday ? 'bg-[#FFBCF4]' : 'bg-[#F9D1FF]'
       } ${dayIndex === 6 ? 'text-red-500' : 'text-black'}`}
     >
-      <span className='block truncate text-sm font-medium' title={day}>
+      <span className='block truncate text-xs font-normal' title={day}>
         {day}
       </span>
     </div>

--- a/widgets/hospital-detail-info-section/ui/ScheduleCell.tsx
+++ b/widgets/hospital-detail-info-section/ui/ScheduleCell.tsx
@@ -11,18 +11,18 @@ export function ScheduleCell({ day, dayIndex, schedule, lang }: ScheduleCellProp
       }`}
     >
       {schedule.isOpen ? (
-        <div className='text-sm text-black'>
-          <div className='truncate font-medium' title={schedule.hours?.split(' ~ ')[0]}>
+        <div className='text-xs text-black'>
+          <div className='truncate font-normal' title={schedule.hours?.split(' ~ ')[0]}>
             {schedule.hours?.split(' ~ ')[0]}
           </div>
           <div className='text-xs text-gray-500'>~</div>
-          <div className='truncate font-medium' title={schedule.hours?.split(' ~ ')[1]}>
+          <div className='truncate font-normal' title={schedule.hours?.split(' ~ ')[1]}>
             {schedule.hours?.split(' ~ ')[1]}
           </div>
         </div>
       ) : (
         <div
-          className={`flex h-full w-full items-center justify-center truncate text-sm font-medium ${isHoliday ? 'text-white' : 'text-gray-500'}`}
+          className={`flex h-full w-full items-center justify-center truncate text-xs font-normal ${isHoliday ? 'text-white' : 'text-gray-500'}`}
         >
           {holidayTexts[lang]}
         </div>


### PR DESCRIPTION
## 변경사항

- **요일 헤더**: text-sm font-medium → text-xs font-normal
- **운영시간**: text-sm font-medium → text-xs font-normal  
- **휴무일**: text-sm font-medium → text-xs font-normal
- **구분자 '~'**: text-xs (변경 없음)

## 수정된 파일
- `widgets/hospital-detail-info-section/ui/DayHeader.tsx`
- `widgets/hospital-detail-info-section/ui/ScheduleCell.tsx`

## 목적
병원 상세 페이지의 진료시간 테이블 폰트 크기를 통일하여 가독성을 개선합니다.