### PR TITLE
feat: 상담 채팅에서 병원 썸네일 이미지 사용

### DIFF
--- a/features/consultation-chat/ui/ConsultationChatClient.tsx
+++ b/features/consultation-chat/ui/ConsultationChatClient.tsx
@@ -65,7 +65,7 @@ export function ConsultationChatClient({ lang, hospitalId, dict }: ConsultationC
   // 메인 채팅 UI
   const hospital = hospitalData?.hospital;
   const hospitalName = hospital ? extractLocalizedText(hospital.name, lang) : '병원';
-  const hospitalImageUrl = hospital?.mainImageUrl || undefined;
+  const hospitalImageUrl = hospital?.thumbnailImageUrl || hospital?.mainImageUrl || undefined;
 
   return (
     <ConsultationChatMain


### PR DESCRIPTION
## 변경사항
- 상담 채팅에서 병원 이미지를 THUMBNAIL 타입으로 우선 사용하도록 변경
- getHospitalDetail API에 thumbnailImageUrl 필드 추가
- 이미지 우선순위: THUMBNAIL → MAIN → 첫 번째 이미지

## 수정된 파일
- `entities/hospital/api/use-cases/get-hospital-detail.ts`
- `features/consultation-chat/ui/ConsultationChatClient.tsx`

## 테스트
- [x] 해당 병원에 THUMBNAIL 타입 이미지 존재 확인
- [x] API 응답에 thumbnailImageUrl 필드 추가 확인
- [x] 상담 채팅에서 썸네일 이미지 우선 사용 확인

## 관련 이슈
상담 채팅 페이지에서 병원 이미지가 썸네일이 아닌 메인 이미지로 표시되는 문제 해결