### PR TITLE
feat: 상담 채팅 말풍선에서 꼬리 제거

### DIFF
--- a/features/consultation-chat/ui/HospitalMessage.tsx
+++ b/features/consultation-chat/ui/HospitalMessage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MessageBubble, MessageTail, MessageTime } from 'shared/ui/message-bubble';
+import { MessageBubble, MessageTime } from 'shared/ui/message-bubble';
 import { HospitalHeader } from 'entities/hospital/ui/HospitalHeader';
 import { type ChatMessage } from '../api/entities/types';
 import { formatMessageTime } from '../lib/chat-utils';
@@ -25,11 +25,6 @@ export function HospitalMessage({
       {showHeader && <HospitalHeader hospitalName={hospitalName} imageUrl={hospitalImageUrl} />}
       <div className='relative box-border flex w-full shrink-0 content-stretch items-end justify-start gap-2 py-0 pr-0 pl-[38px]'>
         <div className='relative flex shrink-0 content-stretch items-start justify-start'>
-          <div className='relative flex shrink-0 items-center justify-center'>
-            <div className='flex-none scale-y-[-100%]'>
-              <MessageTail variant='hospital' />
-            </div>
-          </div>
           <MessageBubble variant='hospital' className='self-stretch'>
             <div className="relative font-['Pretendard:Regular',_sans-serif] text-[14px] leading-[20px] break-words whitespace-pre-wrap text-neutral-900 not-italic">
               {message.content}

--- a/features/consultation-chat/ui/UserMessage.tsx
+++ b/features/consultation-chat/ui/UserMessage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MessageBubble, MessageTail, MessageTime } from 'shared/ui/message-bubble';
+import { MessageBubble, MessageTime } from 'shared/ui/message-bubble';
 import { type ChatMessage } from '../api/entities/types';
 import { formatMessageTime } from '../lib/chat-utils';
 
@@ -22,7 +22,6 @@ export function UserMessage({ message }: UserMessageProps) {
             </div>
           </MessageBubble>
         </div>
-        <MessageTail variant='user' />
       </div>
     </div>
   );


### PR DESCRIPTION
## 변경사항
- 상담 채팅의 말풍선에서 꼬리 부분(MessageTail) 제거
- UserMessage와 HospitalMessage 컴포넌트에서 MessageTail import 및 사용 제거
- 더 깔끔하고 모던한 말풍선 디자인으로 UI 개선

## 수정된 파일
- `features/consultation-chat/ui/UserMessage.tsx`
- `features/consultation-chat/ui/HospitalMessage.tsx`

## UI 개선 효과
- ✅ 더 깔끔한 디자인: 꼬리 제거로 말풍선이 더 모던하고 심플해짐
- ✅ 일관된 스타일: 모든 메시지가 동일한 스타일로 통일됨
- ✅ 공간 효율성: 꼬리로 인한 불필요한 공간 제거

## 테스트
- [x] 사용자 메시지에서 꼬리 제거 확인
- [x] 병원 메시지에서 꼬리 제거 확인
- [x] 레이아웃 간격 조정 확인
- [x] 린터 에러 없음 확인

## 관련 이슈
상담 채팅 말풍선의 꼬리 부분을 제거하여 더 깔끔한 UI로 개선