### PR TITLE
feat: Change 'Do Later' button to 'Sign Up' in login modal

### DIFF
--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -167,7 +167,7 @@
       "email": "Email",
       "password": "Password",
       "loginButton": "Sign In",
-      "laterButton": "Do Later",
+      "laterButton": "Sign Up",
       "requiredMessage": "Please log in\nto use the service.",
       "socialLogin": "Social Login",
       "googleLogin": "Sign in with Google",

--- a/app/[lang]/dictionaries/ko.json
+++ b/app/[lang]/dictionaries/ko.json
@@ -167,7 +167,7 @@
       "email": "이메일",
       "password": "비밀번호",
       "loginButton": "로그인",
-      "laterButton": "나중에 하기",
+      "laterButton": "회원가입하기",
       "requiredMessage": "서비스 이용을 위해\n로그인을 해주세요",
       "socialLogin": "소셜 로그인",
       "googleLogin": "Google로 로그인",

--- a/app/[lang]/dictionaries/th.json
+++ b/app/[lang]/dictionaries/th.json
@@ -167,7 +167,7 @@
       "email": "อีเมล",
       "password": "รหัสผ่าน",
       "loginButton": "เข้าสู่ระบบ",
-      "laterButton": "ทำทีหลัง",
+      "laterButton": "สมัครสมาชิก",
       "requiredMessage": "กรุณาเข้าสู่ระบบเพื่อใช้งานบริการ",
       "socialLogin": "เข้าสู่ระบบด้วยโซเชียล",
       "googleLogin": "เข้าสู่ระบบด้วย Google",

--- a/shared/ui/login-required-modal/LoginRequiredModal.tsx
+++ b/shared/ui/login-required-modal/LoginRequiredModal.tsx
@@ -5,6 +5,7 @@ import { type Locale } from 'shared/config';
 import { type Dictionary } from 'shared/model/types';
 import { useLocalizedRouter } from 'shared/model/hooks/useLocalizedRouter';
 import { getAuthPath } from 'shared/lib/auth/route-guard';
+import { AUTH_CONFIG } from 'shared/config';
 import { closeModal } from 'shared/lib/modal';
 import { CloseIcon } from 'shared/ui/close-icon';
 
@@ -38,6 +39,15 @@ export function LoginRequiredModal({
     const currentPath = redirectPath || window.location.pathname;
     const authPath = getAuthPath(lang);
     router.push(`${authPath}?redirect=${encodeURIComponent(currentPath)}`);
+  };
+
+  const handleSignup = () => {
+    closeModal();
+
+    // 리다이렉트 경로 설정
+    const currentPath = redirectPath || window.location.pathname;
+    const signupPath = `/${lang}${AUTH_CONFIG.signupPath}`;
+    router.push(`${signupPath}?redirect=${encodeURIComponent(currentPath)}`);
   };
 
   // 언어별 배경 이미지 경로 생성
@@ -84,7 +94,7 @@ export function LoginRequiredModal({
               {dict.auth.login.loginButton}
             </button>
             <button
-              onClick={closeModal}
+              onClick={handleSignup}
               className='text-sm font-normal text-neutral-500 transition-colors hover:text-neutral-700'
             >
               {dict.auth.login.laterButton}


### PR DESCRIPTION
## Changes
- Changed 'Do Later' button to 'Sign Up' in login modal
- Multi-language support: Korean, English, Thai
- Added functionality to navigate to signup page when button is clicked

## Modified Files
- app/[lang]/dictionaries/ko.json
- app/[lang]/dictionaries/en.json
- app/[lang]/dictionaries/th.json
- shared/ui/login-required-modal/LoginRequiredModal.tsx

## User Experience Improvement
- Changed from login guidance to signup guidance to help acquire new users