### PR TITLE
feat: 모든 병원에서 탭 노출 및 시술상세 준비중 메시지 추가

### DIFF
--- a/widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx
+++ b/widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx
@@ -28,11 +28,13 @@ export function HospitalDetailProceduresTab({
     return <ApgujeongMiracleProcedures hospital={hospital} lang={lang} dict={dict} />;
   }
 
-  // 일반 병원의 경우 기본 메시지
+  // 일반 병원의 경우 준비중 메시지
   return (
-    <div className='flex flex-col items-center justify-center text-center'>
-      <div className='text-base'>{dict.hospitalDetailTabs.proceduresComingSoon}</div>
-      <div className='mt-2 text-sm'>{dict.hospitalDetailTabs.comingSoonSubtext}</div>
+    <div className='flex min-h-[200px] flex-col items-center justify-center text-center'>
+      <div className='text-base font-medium text-neutral-700'>
+        {dict.hospitalDetailTabs.proceduresComingSoon}
+      </div>
+      <div className='mt-2 text-sm text-neutral-500'>{dict.hospitalDetailTabs.comingSoonSubtext}</div>
     </div>
   );
 }

--- a/widgets/hospital-detail-tabs/ui/HospitalDetailTabs.tsx
+++ b/widgets/hospital-detail-tabs/ui/HospitalDetailTabs.tsx
@@ -7,7 +7,6 @@ import { HospitalDetailIntroductionTab } from './HospitalDetailIntroductionTab';
 import { HospitalDetailProceduresTab } from './HospitalDetailProceduresTab';
 import { HospitalDetailTabsHeader } from './HospitalDetailTabsHeader';
 import { type Hospital } from 'entities/hospital/api/entities/types';
-import { APGUJEONG_MIRACLE_HOSPITAL_ID } from 'shared/config/hospital-constants';
 
 interface HospitalDetailTabsProps {
   hospital: Hospital;
@@ -18,25 +17,6 @@ interface HospitalDetailTabsProps {
 
 export function HospitalDetailTabs({ hospital, hospitalId, lang, dict }: HospitalDetailTabsProps) {
   const [activeTab, setActiveTab] = useState(0);
-
-  // 압구정미라클 의원인지 확인
-  const isApgujeongMiracle = hospitalId === APGUJEONG_MIRACLE_HOSPITAL_ID;
-
-  // 압구정미라클 의원일 때만 탭 표시
-  if (!isApgujeongMiracle) {
-    return (
-      <div className='w-full border-t border-white/60'>
-        <div className='px-5 py-6'>
-          <HospitalDetailIntroductionTab
-            hospital={hospital}
-            hospitalId={hospitalId}
-            lang={lang}
-            dict={dict}
-          />
-        </div>
-      </div>
-    );
-  }
 
   const tabs = [
     { id: 0, label: dict.hospitalDetailTabs.introduction },


### PR DESCRIPTION
## 📋 변경 사항

### 🎯 주요 개선사항
- 압구정미라클 의원이 아닌 병원에서도 **병원소개**와 **시술상세** 탭 노출
- 시술상세 탭에서 압구정미라클 외 병원은 준비중 메시지 표시
- 준비중 메시지 스타일 개선 (중앙 정렬, 적절한 여백 및 색상)

### 🔧 수정된 파일
- `widgets/hospital-detail-tabs/ui/HospitalDetailTabs.tsx`
  - 압구정미라클 의원 체크 로직 제거
  - 모든 병원에서 탭 헤더 표시
  
- `widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx`
  - 준비중 메시지 스타일 개선

### 💬 다국어 지원
- **한국어**: "시술상세 컨텐츠가 준비 중입니다. 곧 업데이트 예정입니다."
- **영어**: "Procedure details are coming soon. Updates coming soon..."
- **태국어**: "รายละเอียดการรักษากำลังเตรียมการ อัปเดตเร็วๆ นี้..."

## 🧪 테스트
- [ ] 압구정미라클 의원에서 시술상세 탭 정상 노출 확인
- [ ] 일반 병원에서 탭 노출 및 준비중 메시지 확인
- [ ] 다국어 메시지 확인 (ko, en, th)