### PR TITLE
feat: 로그인 팝업창의 나중에 하기 버튼을 회원가입하기로 변경

### DIFF
--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -168,6 +168,7 @@
       "password": "Password",
       "loginButton": "Sign In",
       "laterButton": "Do Later",
+      "signupButton": "Sign Up",
       "requiredMessage": "Please log in\nto use the service.",
       "socialLogin": "Social Login",
       "googleLogin": "Sign in with Google",

--- a/app/[lang]/dictionaries/ko.json
+++ b/app/[lang]/dictionaries/ko.json
@@ -168,6 +168,7 @@
       "password": "비밀번호",
       "loginButton": "로그인",
       "laterButton": "나중에 하기",
+      "signupButton": "회원가입하기",
       "requiredMessage": "서비스 이용을 위해\n로그인을 해주세요",
       "socialLogin": "소셜 로그인",
       "googleLogin": "Google로 로그인",

--- a/app/[lang]/dictionaries/th.json
+++ b/app/[lang]/dictionaries/th.json
@@ -168,6 +168,7 @@
       "password": "รหัสผ่าน",
       "loginButton": "เข้าสู่ระบบ",
       "laterButton": "ทำทีหลัง",
+      "signupButton": "สมัครสมาชิก",
       "requiredMessage": "กรุณาเข้าสู่ระบบเพื่อใช้งานบริการ",
       "socialLogin": "เข้าสู่ระบบด้วยโซเชียล",
       "googleLogin": "เข้าสู่ระบบด้วย Google",

--- a/shared/ui/login-required-modal/LoginRequiredModal.tsx
+++ b/shared/ui/login-required-modal/LoginRequiredModal.tsx
@@ -40,6 +40,14 @@ export function LoginRequiredModal({
     router.push(`${authPath}?redirect=${encodeURIComponent(currentPath)}`);
   };
 
+  const handleSignup = () => {
+    closeModal();
+
+    // 리다이렉트 경로 설정
+    const currentPath = redirectPath || window.location.pathname;
+    router.push(`/${lang}/auth/signup?redirect=${encodeURIComponent(currentPath)}`);
+  };
+
   // 언어별 배경 이미지 경로 생성
   const getBackgroundImagePath = (locale: Locale): string => {
     const localeMap = {
@@ -84,10 +92,10 @@ export function LoginRequiredModal({
               {dict.auth.login.loginButton}
             </button>
             <button
-              onClick={closeModal}
+              onClick={handleSignup}
               className='text-sm font-normal text-neutral-500 transition-colors hover:text-neutral-700'
             >
-              {dict.auth.login.laterButton}
+              {dict.auth.login.signupButton}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## 📋 변경 사항

### 🎯 주요 개선사항
- 로그인 팝업창의 "나중에 하기" 버튼을 "회원가입하기" 버튼으로 변경
- 회원가입하기 버튼 클릭 시 회원가입 페이지로 이동
- 리다이렉트 경로 유지하여 회원가입 후 원래 페이지로 복귀

### 🔧 수정된 파일
- `shared/ui/login-required-modal/LoginRequiredModal.tsx`
  - `handleSignup` 함수 추가
  - 버튼 클릭 핸들러를 `closeModal`에서 `handleSignup`으로 변경
  - 버튼 텍스트를 `dict.auth.login.laterButton`에서 `dict.auth.login.signupButton`으로 변경

- `app/[lang]/dictionaries/ko.json`
  - `signupButton`: "회원가입하기" 추가

- `app/[lang]/dictionaries/en.json`
  - `signupButton`: "Sign Up" 추가

- `app/[lang]/dictionaries/th.json`
  - `signupButton`: "สมัครสมาชิก" 추가

### 💬 다국어 지원
- **한국어**: "회원가입하기"
- **영어**: "Sign Up"
- **태국어**: "สมัครสมาชิก"

### 🔄 사용자 플로우
1. 사용자가 로그인이 필요한 기능 시도
2. 로그인 팝업창 표시
3. "회원가입하기" 버튼 클릭
4. 회원가입 페이지로 이동 (리다이렉트 경로 포함)
5. 회원가입 완료 후 원래 페이지로 복귀

## 🧪 테스트
- [ ] 로그인 팝업창에서 회원가입하기 버튼 표시 확인
- [ ] 회원가입하기 버튼 클릭 시 회원가입 페이지 이동 확인
- [ ] 다국어 메시지 확인 (ko, en, th)
- [ ] 리다이렉트 경로 정상 동작 확인