### PR TITLE
refactor: 시술상세 탭 UI 개선

### DIFF
--- a/widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx
+++ b/widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx
@@ -30,11 +30,10 @@ export function HospitalDetailProceduresTab({
 
   // 일반 병원의 경우 준비중 메시지
   return (
-    <div className='flex min-h-[200px] flex-col items-center justify-center text-center'>
-      <div className='text-base font-medium text-neutral-700'>
+    <div className='flex h-[160px] flex-col items-center justify-center text-center'>
+      <div className='text-base font-medium text-primary'>
         {dict.hospitalDetailTabs.proceduresComingSoon}
       </div>
-      <div className='mt-2 text-sm text-neutral-500'>{dict.hospitalDetailTabs.comingSoonSubtext}</div>
     </div>
   );
 }

--- a/widgets/hospital-detail-tabs/ui/HospitalDetailTabs.tsx
+++ b/widgets/hospital-detail-tabs/ui/HospitalDetailTabs.tsx
@@ -51,7 +51,7 @@ export function HospitalDetailTabs({ hospital, hospitalId, lang, dict }: Hospita
 
         {/* 시술상세 탭 */}
         <div
-          className={`px-5 py-6 transition-opacity duration-300 ${
+          className={`px-5 pt-6 transition-opacity duration-300 ${
             activeTab === 1 ? 'opacity-100' : 'pointer-events-none absolute inset-0 opacity-0'
           }`}
         >


### PR DESCRIPTION
## 변경사항

### 시술상세 탭 UI 개선
- **"곧 업데이트 예정입니다." 문구 제거**: 준비중 메시지에서 불필요한 서브텍스트 제거
- **영역 높이 최적화**: 준비중 메시지 영역 높이를 160px로 고정하여 더 컴팩트하게 표시
- **패딩 조정**: 하단 24px 패딩 제거 (py-6 → pt-6)
- **폰트 컬러 변경**: text-neutral-700에서 text-primary로 변경하여 브랜드 컬러 적용

### 수정된 파일
- `widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx`
- `widgets/hospital-detail-tabs/ui/HospitalDetailTabs.tsx`

### 테스트
- [x] 압구정미라클의원이 아닌 병원에서 시술상세 탭 확인
- [x] UI 레이아웃 및 스타일링 확인