### PR TITLE
docs: 시술상세 탭 컴포넌트 주석에 마침표 추가

### DIFF
--- a/widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx
+++ b/widgets/hospital-detail-tabs/ui/HospitalDetailProceduresTab.tsx
@@ -12,7 +12,7 @@ interface HospitalDetailProceduresTabProps {
 }
 
 /**
- * 시술상세 탭 컨텐츠 컴포넌트
+ * 시술상세 탭 컨텐츠 컴포넌트.
  * 압구정 미라클 의원의 경우 특별한 시술상세 컨텐츠를 보여줍니다.
  */
 export function HospitalDetailProceduresTab({


### PR DESCRIPTION
시술상세 탭 컴포넌트의 JSDoc 주석에 마침표를 추가하여 문서 일관성을 개선했습니다.