### PR TITLE
feat: 모든 병원 카드에 HOT 태그(ranking) 표시 기능 추가

### DIFF
--- a/app/api/doctors/[id]/route.ts
+++ b/app/api/doctors/[id]/route.ts
@@ -29,6 +29,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
             rating: true,
             prices: true,
             discountRate: true,
+            ranking: true,
             displayLocationName: true,
             District: {
               select: {
@@ -158,6 +159,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
         reviewCount: doctor.Hospital._count.Review, // 실제 리뷰 수
         prices: doctor.Hospital.prices,
         discountRate: doctor.Hospital.discountRate,
+        ranking: doctor.Hospital.ranking,
         displayLocationName: doctor.Hospital.displayLocationName
           ? parseLocalizedText(doctor.Hospital.displayLocationName)
           : null,

--- a/entities/review/api/use-cases/get-all-reviews.ts
+++ b/entities/review/api/use-cases/get-all-reviews.ts
@@ -119,6 +119,7 @@ export async function getAllReviews({
             prices: true,
             rating: true,
             discountRate: true,
+            ranking: true,
             displayLocationName: true,
             District: {
               select: {
@@ -213,6 +214,7 @@ export async function getAllReviews({
           reviewCount: review.Hospital._count.Review,
           thumbnailImageUrl: review.Hospital.HospitalImage[0]?.imageUrl || null,
           discountRate: review.Hospital.discountRate,
+          ranking: review.Hospital.ranking,
           district: {
             name: review.Hospital.District?.name
               ? parseLocalizedText(review.Hospital.District.name)

--- a/entities/review/api/use-cases/get-hospital-reviews.ts
+++ b/entities/review/api/use-cases/get-hospital-reviews.ts
@@ -56,6 +56,7 @@ export async function getHospitalReviews({
             prices: true,
             rating: true,
             discountRate: true,
+            ranking: true,
             displayLocationName: true,
             District: {
               select: {
@@ -152,6 +153,7 @@ export async function getHospitalReviews({
           reviewCount: review.Hospital._count.Review,
           thumbnailImageUrl: review.Hospital.HospitalImage[0]?.imageUrl || null,
           discountRate: review.Hospital.discountRate,
+          ranking: review.Hospital.ranking,
           district: {
             name: review.Hospital.District?.name
               ? parseLocalizedText(review.Hospital.District.name)

--- a/entities/review/api/use-cases/get-review-detail.ts
+++ b/entities/review/api/use-cases/get-review-detail.ts
@@ -66,6 +66,7 @@ export async function getReviewDetail({
             prices: true,
             rating: true,
             discountRate: true,
+            ranking: true,
             displayLocationName: true,
             District: {
               select: {
@@ -154,6 +155,7 @@ export async function getReviewDetail({
         reviewCount: review.Hospital._count.Review,
         thumbnailImageUrl: review.Hospital.HospitalImage[0]?.imageUrl || null,
         discountRate: review.Hospital.discountRate,
+        ranking: review.Hospital.ranking,
         district: {
           name: review.Hospital.District?.name
             ? parseLocalizedText(review.Hospital.District.name)

--- a/entities/review/lib/convert-hospital-data.ts
+++ b/entities/review/lib/convert-hospital-data.ts
@@ -16,6 +16,7 @@ export function convertReviewHospitalToHospitalCard(review: ReviewCardData): Hos
     reviewCount: review.hospital.reviewCount,
     thumbnailImageUrl: review.hospital.thumbnailImageUrl,
     discountRate: review.hospital.discountRate,
+    ranking: review.hospital.ranking,
     district: review.hospital.district
       ? {
           id: '', // ReviewCardData에는 id가 없으므로 빈 문자열

--- a/entities/review/model/types.ts
+++ b/entities/review/model/types.ts
@@ -78,6 +78,7 @@ export type ReviewCardData = {
     reviewCount: number;
     thumbnailImageUrl: string | null;
     discountRate: number | null;
+    ranking: number | null;
     district: {
       name: LocalizedText;
       displayName?: LocalizedText | null;

--- a/features/consultation-request/lib/convert-hospital-to-card-data.ts
+++ b/features/consultation-request/lib/convert-hospital-to-card-data.ts
@@ -34,5 +34,7 @@ export function convertHospitalToCardData(hospital: Hospital): HospitalCardData 
     likeCount: hospital.likeCount,
     isLiked: hospital.isLiked,
     likedUserIds: hospital.likedUserIds,
+    // HOT 태그 표시를 위한 ranking
+    ranking: hospital.ranking,
   };
 }

--- a/features/favorites-tabs/lib/convertLikedHospitalData.ts
+++ b/features/favorites-tabs/lib/convertLikedHospitalData.ts
@@ -32,6 +32,8 @@ export function convertLikedHospitalToCardData(likedHospital: LikedHospital): Ho
     likeCount: likedHospital.likeCount,
     isLiked: likedHospital.isLiked,
     likedUserIds: likedHospital.likedUserIds,
+    // HOT 태그 표시를 위한 ranking
+    ranking: likedHospital.ranking,
   };
 }
 

--- a/lib/queries/doctor.ts
+++ b/lib/queries/doctor.ts
@@ -24,6 +24,7 @@ export interface DoctorDetail {
     reviewCount: number;
     prices: Prisma.JsonValue;
     discountRate: number | null;
+    ranking: number | null;
     displayLocationName: LocalizedText | null;
     district: {
       id: string;

--- a/lib/utils/doctor-hospital-transform.ts
+++ b/lib/utils/doctor-hospital-transform.ts
@@ -25,6 +25,7 @@ export function transformDoctorHospitalToHospitalCard(doctor: DoctorDetail): Hos
     reviewCount: doctor.hospital.reviewCount,
     thumbnailImageUrl,
     discountRate: doctor.hospital.discountRate,
+    ranking: doctor.hospital.ranking,
     medicalSpecialties: doctor.hospital.medicalSpecialties.map((specialty) => ({
       id: specialty.id,
       name: specialty.name,


### PR DESCRIPTION
## 📝 변경사항

### 주요 기능
- 모든 병원 카드 컴포넌트에서 ranking 데이터 기반 HOT 태그 표시
- ranking 50 이하인 병원에 HOT 태그 자동 표시

### 수정 내용
1. **변환 함수 수정**
   - consultation-request의 convertHospitalToCardData에 ranking 추가
   - doctor-hospital-transform에 ranking 추가
   - review의 convertReviewHospitalToHospitalCard에 ranking 추가
   - favorites의 convertLikedHospitalToCardData에 ranking 추가

2. **API 수정**
   - 의사 상세 API에서 병원 ranking 정보 포함
   - getAllReviews API에 ranking 추가
   - getReviewDetail API에 ranking 추가
   - getHospitalReviews API에 ranking 추가

3. **타입 정의 수정**
   - DoctorDetail 타입에 hospital.ranking 필드 추가
   - ReviewCardData 타입에 hospital.ranking 필드 추가

### 영향 범위
- 의사 상세 페이지의 소속병원 카드
- 리뷰 페이지의 병원 정보
- 즐겨찾기 병원 목록
- 상담 요청 페이지의 병원 카드

### 테스트 방법
1. 의사 상세 페이지에서 소속병원에 HOT 태그 표시 확인
2. ranking 50 이하인 병원에만 HOT 태그가 표시되는지 확인