### PR TITLE
fix: 병원 카드 HOT 태그(ranking) 표시 기능 완전 수정

### DIFF
--- a/features/favorites-tabs/api-server/repositories/liked-reviews-repository.ts
+++ b/features/favorites-tabs/api-server/repositories/liked-reviews-repository.ts
@@ -60,6 +60,7 @@ export class LikedReviewsRepository {
                 prices: true,
                 rating: true,
                 discountRate: true,
+                ranking: true,
                 District: {
                   select: {
                     name: true,
@@ -166,6 +167,7 @@ export class LikedReviewsRepository {
           reviewCount: review.Hospital._count.Review,
           thumbnailImageUrl: review.Hospital.HospitalImage[0]?.imageUrl || null,
           discountRate: review.Hospital.discountRate,
+          ranking: review.Hospital.ranking,
           district: {
             name: review.Hospital.District?.name
               ? parseLocalizedText(review.Hospital.District.name)

--- a/lib/utils/doctor-reviews-transform.ts
+++ b/lib/utils/doctor-reviews-transform.ts
@@ -40,6 +40,7 @@ export function transformDoctorReviewsToReviewCardData(doctor: DoctorDetail): Re
         doctor.hospital.hospitalImages[0]?.imageUrl ||
         null,
       discountRate: doctor.hospital.discountRate,
+      ranking: doctor.hospital.ranking,
       district: doctor.hospital.district
         ? {
             name: doctor.hospital.district.name,


### PR DESCRIPTION
## 📝 변경사항

### 주요 기능
- 모든 병원 카드 컴포넌트에서 ranking 데이터 기반 HOT 태그 표시
- ranking 50 이하인 병원에 HOT 태그 자동 표시

### 수정 내용
1. **변환 함수 수정**
   - consultation-request의 convertHospitalToCardData에 ranking 추가
   - doctor-hospital-transform에 ranking 추가
   - review의 convertReviewHospitalToHospitalCard에 ranking 추가
   - favorites의 convertLikedHospitalToCardData에 ranking 추가
   - doctor-reviews-transform에 ranking 추가

2. **API 수정**
   - 의사 상세 API에서 병원 ranking 정보 포함
   - getAllReviews API에 ranking 추가
   - getReviewDetail API에 ranking 추가
   - getHospitalReviews API에 ranking 추가
   - liked-reviews-repository에 ranking 추가

3. **타입 정의 수정**
   - DoctorDetail 타입에 hospital.ranking 필드 추가
   - ReviewCardData 타입에 hospital.ranking 필드 추가

### 영향 범위
- 의사 상세 페이지의 소속병원 카드
- 리뷰 페이지의 병원 정보
- 즐겨찾기 병원/리뷰 목록
- 상담 요청 페이지의 병원 카드

### 테스트 방법
1. 의사 상세 페이지에서 소속병원에 HOT 태그 표시 확인
2. ranking 50 이하인 병원에만 HOT 태그가 표시되는지 확인
3. 타입 에러 없이 빌드 성공 확인