### PR TITLE
feat: 리뷰 상세 페이지 이미지/텍스트 영역에 shadow와 blur 효과 추가

### DIFF
--- a/entities/review/ui/ReviewDetailContent.tsx
+++ b/entities/review/ui/ReviewDetailContent.tsx
@@ -49,7 +49,7 @@ export function ReviewDetailContent({ review, lang, dict }: ReviewDetailContentP
       <div className='p-5'>
         <div className=''>
           {/* 리뷰 컨텐츠 */}
-          <div className='rounded-t-xl border border-white bg-white/50 p-5'>
+          <div className='rounded-t-xl border border-white bg-white/50 p-5 shadow-[1px_1px_12px_0_rgba(76,25,168,0.12)] backdrop-blur-[6px]'>
             {/* 첫 번째 섹션: 프로필 사진, 닉네임, 작성일자, 평점 */}
             <ReviewListCardHeader review={review} lang={lang} />
 


### PR DESCRIPTION
## 📝 변경사항

### 주요 기능
- 리뷰 상세 페이지의 이미지/텍스트 영역에 shadow와 blur 효과 추가
- 댓글 숫자 영역(ReviewStatsSection)과 동일한 비주얼 스타일로 통일

### 수정 내용
**ReviewDetailContent 컴포넌트**
- 리뷰 컨텐츠 영역에 shadow 효과 추가: `shadow-[1px_1px_12px_0_rgba(76,25,168,0.12)]`
- 리뷰 컨텐츠 영역에 blur 효과 추가: `backdrop-blur-[6px]`
- ReviewStatsSection과 동일한 스타일로 통일하여 더 나은 UI 일관성 제공

### 영향 범위
- 리뷰 상세 페이지 (`/review/[id]`)
- 이미지/텍스트 영역의 비주얼 개선

### 스크린샷
- 기존: 이미지/텍스트 영역만 평면적
- 개선: 댓글 영역과 동일한 shadow/blur 효과로 입체감 추가