### PR TITLE
fix: align bullet points to first line in caution section

### DIFF
--- a/widgets/caution-section/ui/CautionSection.tsx
+++ b/widgets/caution-section/ui/CautionSection.tsx
@@ -21,10 +21,10 @@ export function CautionSection({ lang, dict }: CautionSectionProps) {
       return (
         <div
           key={index}
-          className='relative flex w-full shrink-0 content-stretch items-center justify-start gap-1'
+          className='relative flex w-full shrink-0 content-stretch items-start justify-start gap-1'
         >
-          <div className='flex flex-row items-center self-stretch'>
-            <div className='relative flex h-full shrink-0 content-stretch items-center justify-start gap-2.5'>
+          <div className='flex flex-row items-start self-stretch'>
+            <div className='relative flex h-full shrink-0 content-stretch items-start justify-start gap-2.5 pt-[7px]'>
               <BulletPoint />
             </div>
           </div>


### PR DESCRIPTION
## 변경 사항

### 유의사항 섹션 불릿 포인트 정렬 수정

유의사항 섹션의 화이트 라운드 점이 텍스트가 여러 줄이 되어도 항상 첫 번째 줄에 붙어있도록 개선했습니다.

#### 수정된 컴포넌트
- `CautionSection.tsx`: 불릿 포인트 정렬 방식 개선

#### 주요 변경사항

**문제점**
- 텍스트가 2줄 이상일 때 화이트 점이 중앙 정렬되어 첫 번째 줄과 맞지 않음
- 가독성 저하 및 시각적 일관성 부족

**해결 방법**
- `items-center` → `items-start`: 중앙 정렬에서 상단 정렬로 변경
- `pt-[7px]` 추가: 텍스트의 첫 줄과 점을 수직으로 정렬

#### 적용 페이지
- ✅ `/ko/main` - 메인 페이지 유의사항 섹션
- ✅ 다국어 모든 페이지 (`ko`, `en`, `th`)

#### 개선 효과
- 텍스트 길이에 관계없이 일관된 불릿 포인트 정렬
- 향상된 가독성과 시각적 일관성
- 다양한 언어의 텍스트 길이 변화에도 안정적인 레이아웃