### PR TITLE
feat: Fix last category button width in CategorySection

### DIFF
--- a/features/category-filter/ui/CategorySection.tsx
+++ b/features/category-filter/ui/CategorySection.tsx
@@ -110,10 +110,10 @@ export function CategorySection({
                     categoryButton.type === 'all'
                       ? '!w-[60px] pr-[10px]'
                       : isLast
-                        ? 'mr-5 !w-auto'
+                        ? 'mr-5 !w-[71px]'
                         : ''
                   }
-                  labelClassName={isLast ? 'whitespace-nowrap' : ''}
+                  labelClassName={isLast ? '' : ''}
                 />
               </CarouselItem>
             );


### PR DESCRIPTION
## 🎯 변경사항

### 주요 개선사항
- **마지막 카테고리 버튼 너비 수정**:  →  (고정 71px)
- **텍스트 줄바꿈 개선**:  제거로 자연스러운 줄바꿈 허용
- **운영 사이트와 일치**: 실제 k-doc.kr 사이트와 동일한 레이아웃 적용

## 🔧 기술적 변경사항

### Before
- 마지막 버튼: `mr-5 !w-auto` (자동 너비)
- 라벨 클래스: `whitespace-nowrap` (줄바꿈 방지)

### After  
- 마지막 버튼: `mr-5 !w-[71px]` (71px 고정 너비)
- 라벨 클래스: 기본값 (자연스러운 줄바꿈 허용)

## 📱 UI/UX 개선
- ✅ 모든 언어에서 일관된 마지막 버튼 너비 (71px)
- ✅ 태국어 "โรคผิวหนัง" 텍스트 적절한 표시
- ✅ 운영 사이트와 동일한 레이아웃 구현
- ✅ 오른쪽 마진 20px 유지

## 🧪 테스트 완료
- [x] 로컬 환경 테스트 (http://localhost:3003/th/reviews)
- [x] 다국어 지원 확인 (ko, en, th)
- [x] 운영 사이트 비교 (https://www.k-doc.kr/en/reviews)
- [x] 린터 오류 없음 확인

## 📂 수정된 파일
- `features/category-filter/ui/CategorySection.tsx`

## 🎨 효과
리뷰 페이지의 카테고리 필터에서 마지막 버튼(피부과)이 다른 버튼들과 동일한 71px 너비로 표시되어 일관된 레이아웃을 제공합니다.