### PR TITLE
feat: 정보 수정/삭제 요청 버튼 컬러 변경

### DIFF
--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -603,7 +603,8 @@
     "companyInfo": "About Us",
     "termsOfService": "Terms of Service",
     "privacyPolicy": "Privacy Policy",
-    "contactUs": "Contact Us"
+    "contactUs": "Contact Us",
+    "dataRequest": "Request Edit/Deletion"
   },
   "about": {
     "title": "About Us",

--- a/app/[lang]/dictionaries/ko.json
+++ b/app/[lang]/dictionaries/ko.json
@@ -602,7 +602,8 @@
     "companyInfo": "회사소개",
     "termsOfService": "이용약관",
     "privacyPolicy": "개인정보 처리방침",
-    "contactUs": "Contact us"
+    "contactUs": "Contact us",
+    "dataRequest": "정보 수정/삭제 요청"
   },
   "about": {
     "title": "회사소개",

--- a/app/[lang]/dictionaries/th.json
+++ b/app/[lang]/dictionaries/th.json
@@ -603,7 +603,8 @@
     "companyInfo": "About Us",
     "termsOfService": "ข้อกำหนดในการให้บริการ",
     "privacyPolicy": "นโยบายความเป็นส่วนตัว",
-    "contactUs": "ติดต่อเรา"
+    "contactUs": "ติดต่อเรา",
+    "dataRequest": "ร้องขอแก้ไข/ลบ"
   },
   "about": {
     "title": "เกี่ยวกับเรา",

--- a/shared/config/policy-links.ts
+++ b/shared/config/policy-links.ts
@@ -14,6 +14,11 @@ export const POLICY_LINKS = {
     en: 'https://hypnotic-dryosaurus-c5c.notion.site/Privacy-Policy-27ad3f7f900d80d38997e64cad05ddc1?source=copy_link',
     th: 'https://hypnotic-dryosaurus-c5c.notion.site/27ad3f7f900d8077b3dad6848a30093c?source=copy_link',
   },
+  dataRequest: {
+    ko: 'https://forms.gle/Vf419Ke2TKBhwEK57',
+    en: 'https://forms.gle/trZV5WsojheuNy5X8',
+    th: 'https://forms.gle/FSY2anBUy8YgKGGz6',
+  },
 } as const;
 
 /**
@@ -32,4 +37,13 @@ export const getTermsOfServiceLink = (locale: Locale): string => {
  */
 export const getPrivacyPolicyLink = (locale: Locale): string => {
   return POLICY_LINKS.privacyPolicy[locale] as string;
+};
+
+/**
+ * 언어에 따른 정보 수정/삭제 요청 링크를 반환합니다.
+ * @param locale 언어 설정
+ * @returns 해당 언어의 정보 수정/삭제 요청 링크
+ */
+export const getDataRequestLink = (locale: Locale): string => {
+  return POLICY_LINKS.dataRequest[locale] as string;
 };

--- a/widgets/footer/ui/Footer.tsx
+++ b/widgets/footer/ui/Footer.tsx
@@ -12,7 +12,7 @@ interface FooterProps {
 
 export function Footer({ lang, dict }: FooterProps) {
   return (
-    <footer className='bg-gradient-to-t from-[#FCE4FF] to-[#FCE4FF] px-5 pt-5 pb-9'>
+    <footer className='bg-gradient-to-t from-[#FCE4FF] to-[#FCE4FF] px-5 pt-5 pb-16'>
       {/* 상단 섹션: 로고와 회사소개 버튼 */}
       <div className='mb-4 flex items-center justify-between'>
         <FooterLogo />

--- a/widgets/footer/ui/FooterPolicyLinks.tsx
+++ b/widgets/footer/ui/FooterPolicyLinks.tsx
@@ -1,6 +1,6 @@
 import { type Locale } from 'shared/config';
 import { type Dictionary } from 'shared/model/types';
-import { getTermsOfServiceLink, getPrivacyPolicyLink } from 'shared/config/policy-links';
+import { getTermsOfServiceLink, getPrivacyPolicyLink, getDataRequestLink } from 'shared/config/policy-links';
 import { LocaleLink } from 'shared/ui/locale-link';
 
 interface FooterPolicyLinksProps {
@@ -10,26 +10,41 @@ interface FooterPolicyLinksProps {
 
 export function FooterPolicyLinks({ lang, dict }: FooterPolicyLinksProps) {
   return (
-    <div className='flex items-center justify-between text-xs font-medium text-neutral-500'>
-      <a
-        href={getTermsOfServiceLink(lang)}
-        target='_blank'
-        rel='noopener noreferrer'
-        className='transition-colors hover:text-neutral-800'
-      >
-        {dict.footer.termsOfService}
-      </a>
-      <a
-        href={getPrivacyPolicyLink(lang)}
-        target='_blank'
-        rel='noopener noreferrer'
-        className='transition-colors hover:text-neutral-800'
-      >
-        {dict.footer.privacyPolicy}
-      </a>
-      <LocaleLink href='/contact' className='transition-colors hover:text-neutral-800'>
-        {dict.footer.contactUs}
-      </LocaleLink>
+    <div className='space-y-2 text-xs font-medium text-neutral-500'>
+      {/* 첫 번째 라인: 이용약관 | Contact us */}
+      <div className='flex items-center justify-between'>
+        <a
+          href={getTermsOfServiceLink(lang)}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='transition-colors hover:text-neutral-800'
+        >
+          {dict.footer.termsOfService}
+        </a>
+        <LocaleLink href='/contact' className='transition-colors hover:text-neutral-800'>
+          {dict.footer.contactUs}
+        </LocaleLink>
+      </div>
+      
+      {/* 두 번째 라인: 개인정보 처리방침 | 정보 수정/삭제 요청 */}
+      <div className='flex items-center justify-between'>
+        <a
+          href={getPrivacyPolicyLink(lang)}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='transition-colors hover:text-neutral-800'
+        >
+          {dict.footer.privacyPolicy}
+        </a>
+        <a
+          href={getDataRequestLink(lang)}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='text-neutral-400 transition-colors hover:text-neutral-800'
+        >
+          {dict.footer.dataRequest}
+        </a>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 변경사항

### 주요 변경사항
- **Footer 정책 링크 개선**: 정보 수정/삭제 요청 버튼 컬러를 neutral-400으로 변경
- **다국어 지원 강화**: 각 언어별 사전에 footer 관련 텍스트 추가
- **정책 링크 구조 개선**: policy-links.ts에 새로운 링크 관리 기능 추가

### 상세 변경사항
1. **FooterPolicyLinks 컴포넌트**
   - 정보 수정/삭제 요청 링크의 텍스트 컬러를 neutral-400으로 변경
   - 레이아웃 및 구조 개선

2. **다국어 사전 업데이트**
   - `app/[lang]/dictionaries/ko.json`: footer 관련 한국어 텍스트 추가
   - `app/[lang]/dictionaries/en.json`: footer 관련 영어 텍스트 추가  
   - `app/[lang]/dictionaries/th.json`: footer 관련 태국어 텍스트 추가

3. **정책 링크 설정**
   - `shared/config/policy-links.ts`: 새로운 정책 링크 관리 기능 추가

4. **Footer 컴포넌트**
   - `widgets/footer/ui/Footer.tsx`: 구조 개선

## 수정된 파일
- `widgets/footer/ui/FooterPolicyLinks.tsx`
- `widgets/footer/ui/Footer.tsx`
- `shared/config/policy-links.ts`
- `app/[lang]/dictionaries/ko.json`
- `app/[lang]/dictionaries/en.json`
- `app/[lang]/dictionaries/th.json`

## 테스트 체크리스트
- [ ] Footer 영역에서 정보 수정/삭제 요청 버튼이 neutral-400 컬러로 표시되는지 확인
- [ ] hover 시 neutral-800으로 변경되는지 확인
- [ ] 각 언어별로 footer 텍스트가 올바르게 표시되는지 확인
- [ ] 정책 링크들이 올바른 URL로 연결되는지 확인