### PR TITLE
feat: 마이페이지 회원탈퇴 버튼 UI 개선

### DIFF
--- a/features/my-page/ui/AccountSection.tsx
+++ b/features/my-page/ui/AccountSection.tsx
@@ -62,19 +62,30 @@ export function AccountSection({ lang, dict }: AccountSectionProps) {
 
   return (
     <div className='flex w-full flex-col gap-5'>
-      <h2 className='text-lg font-semibold text-gray-900'>{dict.my?.account?.title || '계정'}</h2>
+      {/* 계정 타이틀과 회원탈퇴 버튼을 같은 라인에 배치 */}
+      <div className='flex items-center justify-between'>
+        <h2 className='text-lg font-semibold text-gray-900'>{dict.my?.account?.title || '계정'}</h2>
+        
+        {/* 회원탈퇴 - 텍스트만 클릭 가능 */}
+        <div className='flex items-center'>
+          <button
+            type='button'
+            onClick={handleDeleteAccount}
+            disabled={isLoading}
+            className='text-sm font-medium text-neutral-500 transition-colors hover:text-neutral-700 disabled:cursor-not-allowed disabled:opacity-50'
+          >
+            {dict.my?.account?.deleteAccount || '회원탈퇴'}
+          </button>
+          {isLoading && (
+            <div className='ml-2 h-4 w-4 animate-spin rounded-full border-2 border-neutral-300 border-t-neutral-600'></div>
+          )}
+        </div>
+      </div>
 
       <div className='flex w-full flex-col gap-3'>
         <MenuItem
           title={dict.my?.account?.logout || '로그아웃'}
           onClick={handleLogout}
-          disabled={isLoading}
-        />
-        <MenuItem
-          title={dict.my?.account?.deleteAccount || '회원탈퇴'}
-          onClick={handleDeleteAccount}
-          isDanger={true}
-          loading={isLoading}
           disabled={isLoading}
         />
       </div>


### PR DESCRIPTION
## 변경사항

### 마이페이지 회원탈퇴 버튼 UI 개선
- **기존**: MenuItem 컴포넌트를 사용한 배경색이 있는 버튼 형태
- **변경**: 텍스트만 클릭 가능한 심플한 버튼으로 변경

### 상세 변경사항
1. **버튼 스타일 변경**
   - MenuItem 컴포넌트에서 일반 button 요소로 변경
   - 모든 패딩과 배경색 제거
   - 텍스트 영역만 클릭 가능하도록 최적화

2. **컬러 변경**
   - 기본 컬러: `text-red-600` → `text-neutral-500`
   - hover 컬러: `hover:text-red-700` → `hover:text-neutral-700`
   - 로딩 스피너: red 계열 → neutral 계열로 변경

3. **레이아웃 개선**
   - 회원탈퇴 버튼을 계정 타이틀과 같은 라인에 배치
   - `justify-between`을 사용하여 타이틀(왼쪽)과 버튼(오른쪽) 배치
   - 로그아웃 버튼은 기존 위치 유지

### UI/UX 개선 효과
- **심플함**: 불필요한 배경색과 패딩 제거로 깔끔한 디자인
- **직관성**: 텍스트만 클릭 가능하여 사용자 경험 개선
- **일관성**: neutral 컬러로 전체적인 톤앤매너 통일
- **공간 효율성**: 타이틀과 같은 라인 배치로 공간 활용도 향상

## 수정된 파일
- `features/my-page/ui/AccountSection.tsx`

## 테스트 체크리스트
- [ ] 마이페이지(/ko/my)에서 회원탈퇴 버튼이 텍스트 형태로 표시되는지 확인
- [ ] 계정 타이틀과 같은 라인에 배치되어 있는지 확인
- [ ] 텍스트 영역만 클릭 가능한지 확인
- [ ] hover 시 neutral-700 색상으로 변경되는지 확인
- [ ] 로딩 중일 때 neutral 색상의 스피너가 표시되는지 확인
- [ ] 기능적으로 회원탈퇴가 정상 동작하는지 확인