### PR TITLE
feat(tips): K-DOC Tips 섹션 추가 (목록/상세/메인 위젯)

### DIFF
--- a/app/[lang]/tip/[id]/page.tsx
+++ b/app/[lang]/tip/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { type Locale } from 'shared/config';
 import { PageHeaderV2 } from 'shared/ui/page-header';
-import { ShareButton } from 'shared/ui/share-button';
+import { TipShareButton } from 'entities/tip/ui/detail/TipShareButton';
 import { getDictionary } from '../../dictionaries';
 import { TipDetailContent } from './TipDetailContent';
 
@@ -17,7 +17,7 @@ export default async function TipDetailPage({ params }: TipDetailPageProps) {
       <PageHeaderV2
         title=''
         fallbackUrl={`/${lang}/tips`}
-        rightContent={<ShareButton />}
+        rightContent={<TipShareButton id={id} lang={lang} />}
       />
       <div className='h-[58px]' />
       <main className='px-5'>

--- a/entities/tip/ui/detail/TipShareButton.tsx
+++ b/entities/tip/ui/detail/TipShareButton.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { type Locale } from 'shared/config';
+import { ShareButton } from 'shared/ui/share-button';
+import { useTipDetail } from '../../model/useTipDetail';
+
+interface TipShareButtonProps {
+  id: string;
+  lang: Locale;
+}
+
+function getLocalizedTitle(title: Record<string, string>, lang: Locale): string {
+  const shortLang = lang === 'zh-Hant' ? 'zh' : lang;
+  return title[shortLang] ?? title.ko ?? title.en ?? '';
+}
+
+export function TipShareButton({ id, lang }: TipShareButtonProps) {
+  const { data: article } = useTipDetail(id);
+
+  const articleTitle = article
+    ? getLocalizedTitle(article.title as Record<string, string>, lang)
+    : '';
+
+  const shareTitle = articleTitle ? `${articleTitle} - K-DOC` : 'K-DOC';
+  const shareText = articleTitle || 'K-DOC';
+
+  return <ShareButton title={shareTitle} text={shareText} />;
+}


### PR DESCRIPTION
## Summary
- 새로운 **K-DOC Tips** 기능 전반 구현 (BottomNav 진입점, 목록 페이지, 상세 페이지, 메인 페이지 위젯)
- 9개 언어 다국어 지원 (ko/en/th/zh-Hant/ja/hi/tl/ar/ru)
- 마이페이지 \"찜 목록 / 내 예약 내역\" 섹션 추가, Consultation 탭 상태 쿼리파라미터 관리

### 주요 구현
- **Bottom Navigation**: Favorites → Tips로 교체, 신규 `TipsIcon` 추가
- **Tips 목록 페이지** (\`/tips\`): 탑 배너, 정렬 필터(최신순/인기순) — URL 쿼리파라미터 기반, 무한스크롤(TanStack `useInfiniteQuery`), 카드/스켈레톤
- **Tips 상세 페이지** (\`/tip/:id\`): PageHeaderV2(공유 버튼 포함), 카테고리/제목/날짜 헤더, 커버이미지(335:224), TipTap `static-renderer`로 본문 렌더(admin SCSS 그대로 포팅), 추천 병원 섹션, \"병원 더 알아보기\" 버튼, 해시태그, 추천 아티클 섹션, \"후기 보러가기\" 버튼 영역(그라데이션)
- **메인 페이지**: YouTube 섹션 다음에 K-DOC Tips 섹션(3개 미리보기 + 전체보기)
- **마이페이지**: ActivityStats 다음에 \"찜 목록 / 내 예약 내역\" 섹션 추가
- **Consultation**: 탭 상태를 URL 쿼리파라미터로 관리 (`?tab=chat|appointment`)
- **조회수**: 상세 페이지 진입 시 `POST /api/tips/[id]/views`로 +1

### 의존성 추가
- \`@tiptap/core\`, \`@tiptap/pm\`, \`@tiptap/react\`, \`@tiptap/static-renderer\`, \`@tiptap/starter-kit\`, \`@tiptap/extension-*\` (image, text-align, text-style, highlight, emoji, mention, list, table, code-block-lowlight, typography, subscript, superscript, mathematics)
- \`lowlight\`, \`sass\` (admin tiptap-node SCSS 컴파일용)

### API
- \`GET /api/tips\` — 목록 (페이지/limit/sort)
- \`GET /api/tips/[id]\` — 상세 (medicalSpecialties, recommendedHospitals, recommendedArticles join)
- \`POST /api/tips/[id]/views\` — 조회수 증가

## Test plan
- [ ] 바텀 네비게이션의 Tips 탭이 표시되고 \`/tips\`로 이동
- [ ] Tips 목록: 무한스크롤, 정렬 필터(최신순/인기순) URL 쿼리 반영, 새로고침 시 상태 유지
- [ ] Tips 상세: 카테고리/제목/날짜/커버이미지/본문 렌더링이 admin 미리보기와 동일
- [ ] 추천 병원/아티클/해시태그/추천 아티클 섹션이 데이터 있을 때만 렌더링
- [ ] 공유 버튼 클릭 시 아티클 제목이 공유 텍스트로 전달
- [ ] 페이지 진입 시마다 viewCount +1
- [ ] 메인 페이지의 K-DOC Tips 섹션 3개 미리보기 + 전체보기 동작
- [ ] 마이페이지의 \"찜 목록 / 내 예약 내역\" 카드 동작 (각각 \`/favorites\`, \`/consultation?tab=appointment\`)
- [ ] Consultation 페이지의 탭 전환 시 URL 쿼리파라미터 변경 + 새로고침 시 상태 유지
- [ ] 9개 언어 모두에서 라벨 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)