### PR TITLE
feat(notice): Update notice ordering to prioritize pinned notices

### DIFF
--- a/app/api/notices/route.ts
+++ b/app/api/notices/route.ts
@@ -85,9 +85,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
             },
           },
         },
-        orderBy: {
-          createdAt: 'desc', // 최신순
-        },
+        orderBy: [
+          { isPinned: 'desc' }, // 상단고정 먼저
+          { createdAt: 'desc' }, // 최신순
+        ],
         skip,
         take: limit,
       }),


### PR DESCRIPTION
- Modified the ordering of notices in the GET request to first display pinned notices, followed by the most recently created ones. This change enhances visibility for important notices while maintaining chronological order for others.