### PR TITLE
refactor(medical-specialty-tags): Simplify specialty display logic in…

### DIFF
--- a/entities/hospital/ui/HospitalCardV2.tsx
+++ b/entities/hospital/ui/HospitalCardV2.tsx
@@ -108,7 +108,7 @@ export function HospitalCardV2({
                   <MedicalSpecialtyTagsV2
                     specialties={hospitalData.medicalSpecialties}
                     lang={lang}
-                    collapseOverflow
+                    maxDisplay={3}
                   />
                 )}
 

--- a/shared/ui/medical-specialty-tags/MedicalSpecialtyTagsV2.tsx
+++ b/shared/ui/medical-specialty-tags/MedicalSpecialtyTagsV2.tsx
@@ -14,18 +14,10 @@ interface MedicalSpecialtyTagsV2Props {
    * (Deprecated) 기존 호출부 호환용. 현재는 제한 로직을 적용하지 않습니다.
    */
   maxDisplay?: number;
-  /**
-   * 카드처럼 좁은 영역에서 카테고리 개수가 임계값(4) 이상일 때
-   * 앞 2개만 노출하고 나머지는 "+N" 배지로 표시합니다.
-   */
-  collapseOverflow?: boolean;
   className?: string;
   tagClassName?: string;
   textClassName?: string;
 }
-
-const COLLAPSE_THRESHOLD = 4;
-const VISIBLE_WHEN_COLLAPSED = 2;
 
 /**
  * 진료부위 태그 목록 컴포넌트 V2
@@ -35,7 +27,6 @@ export function MedicalSpecialtyTagsV2({
   specialties,
   lang,
   maxDisplay: _maxDisplay,
-  collapseOverflow = false,
   className = '',
   tagClassName = '',
   textClassName = '',
@@ -44,15 +35,9 @@ export function MedicalSpecialtyTagsV2({
     return null;
   }
 
-  const shouldCollapse = collapseOverflow && specialties.length >= COLLAPSE_THRESHOLD;
-  const visibleSpecialties = shouldCollapse
-    ? specialties.slice(0, VISIBLE_WHEN_COLLAPSED)
-    : specialties;
-  const overflowCount = shouldCollapse ? specialties.length - VISIBLE_WHEN_COLLAPSED : 0;
-
   return (
     <div className={`flex flex-wrap gap-1 ${className}`}>
-      {visibleSpecialties.map((specialty) => {
+      {specialties.map((specialty) => {
         const specialtyName = extractLocalizedText(specialty.name, lang) || '';
         return (
           <MedicalSpecialtyTagV2
@@ -63,13 +48,6 @@ export function MedicalSpecialtyTagsV2({
           />
         );
       })}
-      {overflowCount > 0 && (
-        <MedicalSpecialtyTagV2
-          name={`+${overflowCount}`}
-          className={tagClassName}
-          textClassName={textClassName}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
… MedicalSpecialtyTagsV2

- Removed the deprecated `collapseOverflow` prop and its associated logic for handling overflow in specialty tags.
- Introduced a new `maxDisplay` prop to limit the number of displayed specialties directly, enhancing clarity and maintainability.
- Updated HospitalCardV2 to utilize the `maxDisplay` prop, improving the presentation of medical specialties.