### PR TITLE
feat(medical-specialty-tags): Enhance overflow handling in MedicalSpe…

### DIFF
--- a/entities/hospital/ui/HospitalCardV2.tsx
+++ b/entities/hospital/ui/HospitalCardV2.tsx
@@ -108,7 +108,7 @@ export function HospitalCardV2({
                   <MedicalSpecialtyTagsV2
                     specialties={hospitalData.medicalSpecialties}
                     lang={lang}
-                    maxDisplay={3}
+                    collapseOverflow
                   />
                 )}
 

--- a/shared/ui/medical-specialty-tags/MedicalSpecialtyTagsV2.tsx
+++ b/shared/ui/medical-specialty-tags/MedicalSpecialtyTagsV2.tsx
@@ -14,10 +14,18 @@ interface MedicalSpecialtyTagsV2Props {
    * (Deprecated) 기존 호출부 호환용. 현재는 제한 로직을 적용하지 않습니다.
    */
   maxDisplay?: number;
+  /**
+   * 카드처럼 좁은 영역에서 카테고리 개수가 임계값(4) 이상일 때
+   * 앞 2개만 노출하고 나머지는 "+N" 배지로 표시합니다.
+   */
+  collapseOverflow?: boolean;
   className?: string;
   tagClassName?: string;
   textClassName?: string;
 }
+
+const COLLAPSE_THRESHOLD = 4;
+const VISIBLE_WHEN_COLLAPSED = 2;
 
 /**
  * 진료부위 태그 목록 컴포넌트 V2
@@ -27,6 +35,7 @@ export function MedicalSpecialtyTagsV2({
   specialties,
   lang,
   maxDisplay: _maxDisplay,
+  collapseOverflow = false,
   className = '',
   tagClassName = '',
   textClassName = '',
@@ -35,9 +44,15 @@ export function MedicalSpecialtyTagsV2({
     return null;
   }
 
+  const shouldCollapse = collapseOverflow && specialties.length >= COLLAPSE_THRESHOLD;
+  const visibleSpecialties = shouldCollapse
+    ? specialties.slice(0, VISIBLE_WHEN_COLLAPSED)
+    : specialties;
+  const overflowCount = shouldCollapse ? specialties.length - VISIBLE_WHEN_COLLAPSED : 0;
+
   return (
     <div className={`flex flex-wrap gap-1 ${className}`}>
-      {specialties.map((specialty) => {
+      {visibleSpecialties.map((specialty) => {
         const specialtyName = extractLocalizedText(specialty.name, lang) || '';
         return (
           <MedicalSpecialtyTagV2
@@ -48,6 +63,13 @@ export function MedicalSpecialtyTagsV2({
           />
         );
       })}
+      {overflowCount > 0 && (
+        <MedicalSpecialtyTagV2
+          name={`+${overflowCount}`}
+          className={tagClassName}
+          textClassName={textClassName}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
…cialtyTagsV2

- Introduced a `collapseOverflow` prop to manage the display of medical specialties in constrained spaces.
- When enabled, only a limited number of specialties are shown, with the remainder indicated by a "+N" badge for improved UI clarity.
- Updated HospitalCardV2 to utilize the new overflow feature, enhancing the presentation of medical specialties.