### PR TITLE
refactor(get-best-hospitals): Remove hardcoded limit on displayed spe…

### DIFF
--- a/entities/hospital/api/use-cases/get-best-hospitals.ts
+++ b/entities/hospital/api/use-cases/get-best-hospitals.ts
@@ -74,7 +74,6 @@ export async function getBestHospitals(options: GetBestHospitalsOptions = {}) {
               },
             },
           },
-          take: 3, // 최대 3개의 전문 분야만 표시
         },
         District: {
           select: {


### PR DESCRIPTION
…cialties

- Eliminated the hardcoded `take: 3` limit in the `getBestHospitals` function, allowing for more flexible handling of displayed specialties.
- This change enhances the function's adaptability for various use cases and improves overall maintainability.