### PR TITLE
style(ui): Adjust ChatTextArea component styles for improved readability

### DIFF
--- a/features/consultation-chat/ui/ChatTextArea.tsx
+++ b/features/consultation-chat/ui/ChatTextArea.tsx
@@ -56,11 +56,11 @@ export const ChatTextArea = forwardRef<ChatTextAreaRef, ChatTextAreaProps>(
           placeholder={placeholder}
           disabled={disabled}
           rows={1}
-          className="flex w-full resize-none overflow-hidden border-none bg-transparent font-['Pretendard:Medium',_sans-serif] text-[14px] text-neutral-900 outline-none placeholder:text-neutral-400"
+          className="flex w-full resize-none overflow-hidden border-none bg-transparent font-['Pretendard:Medium',_sans-serif] text-sm text-neutral-900 outline-none placeholder:text-neutral-400"
           style={{
             minHeight: '28px',
             maxHeight: '120px',
-            lineHeight: '28px',
+            lineHeight: '20px',
             paddingTop: '0',
             paddingBottom: '0',
           }}


### PR DESCRIPTION
- Updated the text size from 'text-[14px]' to 'text-sm' for better consistency with design standards.
- Changed the line height from '28px' to '20px' to enhance text clarity and spacing within the ChatTextArea component.