### PR TITLE
fix(consultation-request): 생년월일 타임존 버그 수정 및 예약 희망 일시 UI 개선

### DIFF
--- a/app/[lang]/dictionaries/ko.json
+++ b/app/[lang]/dictionaries/ko.json
@@ -788,12 +788,12 @@
           "anytime": "언제든지"
         },
         "preferredDate": {
-          "label": "예약 희망 날짜",
+          "label": "예약 희망 일시",
           "placeholder": "날짜를 선택해주세요",
           "helper": "병원 스케줄 확인을 위해 꼭 선택해주세요"
         },
         "preferredDate2": {
-          "label": "예약 희망 날짜2",
+          "label": "예약 희망 일시 2",
           "placeholder": "날짜를 선택해주세요",
           "helper": "첫번째 날짜가 불가능할 경우에만 참고합니다"
         },
@@ -831,7 +831,7 @@
             "invalid": "올바른 휴대폰 번호를 입력해주세요."
           },
           "preferredDate": {
-            "required": "예약 희망 날짜를 선택해주세요."
+            "required": "예약 희망 일시를 선택해주세요."
           },
           "content": {
             "required": "상담 내용을 입력해주세요.",

--- a/features/consultation-request/ui/ConsultationForm.tsx
+++ b/features/consultation-request/ui/ConsultationForm.tsx
@@ -291,7 +291,7 @@ export function ConsultationForm({ hospitalId, lang, dict }: ConsultationFormPro
 
       {/* 예약 희망 날짜 */}
       <FormDatePickerDrawerV2
-        label={dict.consultation?.request?.form?.preferredDate?.label || '예약 희망 날짜'}
+        label={dict.consultation?.request?.form?.preferredDate?.label || '예약 희망 일시'}
         value={formData.preferredDate ? parseLocalDate(formData.preferredDate) : undefined}
         onChange={(date) => updateField('preferredDate', date ? formatDateToString(date) : '')}
         locale={lang}
@@ -305,7 +305,7 @@ export function ConsultationForm({ hospitalId, lang, dict }: ConsultationFormPro
 
       {/* 예약 희망 날짜2 */}
       <FormDatePickerDrawerV2
-        label={dict.consultation?.request?.form?.preferredDate2?.label || '예약 희망 날짜2'}
+        label={dict.consultation?.request?.form?.preferredDate2?.label || '예약 희망 일시 2'}
         value={formData.preferredDate2 ? parseLocalDate(formData.preferredDate2) : undefined}
         onChange={(date) => updateField('preferredDate2', date ? formatDateToString(date) : '')}
         locale={lang}

--- a/features/consultation-request/ui/ConsultationFormV2.tsx
+++ b/features/consultation-request/ui/ConsultationFormV2.tsx
@@ -20,6 +20,20 @@ import { trackLead, trackGenerateLead } from 'shared/lib/analytics';
 import { COUNTRY_CODES, getCountryName } from 'entities/country-code';
 import { getHospitalClosedWeekdays } from '../lib/hospital-closed-weekdays';
 
+/** "YYYY-MM-DD" 문자열을 로컬 시간 기준 Date로 파싱 (UTC offset 오염 방지) */
+function parseLocalDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/** Date를 로컬 시간 기준 "YYYY-MM-DD" 문자열로 변환 */
+function formatLocalDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 // 아이콘 SVG 컴포넌트들
 const UserIcon = ({ className }: { className?: string }) => (
   <svg className={className} fill='none' stroke='currentColor' viewBox='0 0 24 24'>
@@ -273,9 +287,9 @@ export function ConsultationFormV2({
             dict.auth?.signup?.birthDate ||
             '생년월일'
           }
-          value={formData.birthDate ? new Date(formData.birthDate) : undefined}
+          value={formData.birthDate ? parseLocalDate(formData.birthDate) : undefined}
           onChange={(date) =>
-            updateField('birthDate', date ? date.toISOString().split('T')[0] : '')
+            updateField('birthDate', date ? formatLocalDate(date) : '')
           }
           locale={lang}
           dict={dict}
@@ -306,7 +320,7 @@ export function ConsultationFormV2({
 
         {/* 예약 희망 날짜 */}
         <FormDatePickerDrawerV2
-          label={dict.consultation?.request?.form?.preferredDate?.label || '예약 희망 날짜'}
+          label={dict.consultation?.request?.form?.preferredDate?.label || '예약 희망 일시'}
           value={formData.preferredDate ? parseDateTimeString(formData.preferredDate) : undefined}
           onChange={(date) => updateField('preferredDate', date ? formatDateTimeToString(date) : '')}
           locale={lang}
@@ -326,7 +340,7 @@ export function ConsultationFormV2({
 
         {/* 예약 희망 날짜2 */}
         <FormDatePickerDrawerV2
-          label={dict.consultation?.request?.form?.preferredDate2?.label || '예약 희망 날짜2'}
+          label={dict.consultation?.request?.form?.preferredDate2?.label || '예약 희망 일시 2'}
           value={formData.preferredDate2 ? parseDateTimeString(formData.preferredDate2) : undefined}
           onChange={(date) => updateField('preferredDate2', date ? formatDateTimeToString(date) : '')}
           locale={lang}

--- a/features/consultation-request/ui/FormDatePickerDrawerV2.tsx
+++ b/features/consultation-request/ui/FormDatePickerDrawerV2.tsx
@@ -40,7 +40,19 @@ const DEFAULT_PLACEHOLDER_BY_LOCALE: Record<Locale, string> = {
   ru: 'Выберите дату',
 };
 
-const formatDisplayDate = (date: Date, _locale: Locale): string => {
+const LOCALE_TO_BCP47: Record<Locale, string> = {
+  ko: 'ko-KR',
+  en: 'en-US',
+  th: 'th-TH',
+  'zh-Hant': 'zh-Hant-TW',
+  ja: 'ja-JP',
+  hi: 'hi-IN',
+  tl: 'fil-PH',
+  ar: 'ar-SA',
+  ru: 'ru-RU',
+};
+
+const formatDisplayDate = (date: Date, locale: Locale): string => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
@@ -49,7 +61,10 @@ const formatDisplayDate = (date: Date, _locale: Locale): string => {
   const h = date.getHours();
   const m = date.getMinutes();
   if (h !== 0 || m !== 0) {
-    return `${dateStr} ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')} (KST)`;
+    const weekday = new Intl.DateTimeFormat(LOCALE_TO_BCP47[locale], {
+      weekday: 'short',
+    }).format(date);
+    return `${dateStr} (${weekday}) ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')} (KST)`;
   }
 
   return dateStr;


### PR DESCRIPTION
## Summary

- **생년월일 UTC 오프셋 버그 수정**: `new Date("YYYY-MM-DD")`가 UTC 자정으로 파싱되어 KST에서 1일 밀리는 문제를 로컬 날짜 파싱/포맷으로 교체
- **예약 희망 날짜 요일 추가**: 날짜+시간 표시 시 요일 삽입 (예: `2026-06-17 (화) 11:00 (KST)`)
- **레이블 문구 변경**: "예약 희망 날짜" → "예약 희망 일시" (ko.json 및 fallback 문자열 포함)

## Test plan

- [ ] 생년월일 선택 후 input에 시간 없이 날짜만 표시되는지 확인
- [ ] 예약 희망 일시 선택 후 `YYYY-MM-DD (요일) HH:mm (KST)` 형식으로 표시되는지 확인
- [ ] 폼 제출 후 DB에 올바른 날짜(날짜 밀림 없음)가 저장되는지 확인
- [ ] 한국어 레이블이 "예약 희망 일시"로 표시되는지 확인

Made with [Cursor](https://cursor.com)