### PR TITLE
feat: K-DOC 상담 챗봇 개편 및 병원 목록 필터 개선

### DIFF
--- a/features/consultation-chat/lib/consultation-hospital-link.ts
+++ b/features/consultation-chat/lib/consultation-hospital-link.ts
@@ -1,0 +1,9 @@
+import { K_DOC_HOSPITAL_ID } from 'shared/config/hospital-constants';
+
+/** 상담채팅에서 병원 로고/헤더 클릭 시 이동할 병원상세 URL. K-DOC 병원은 예외로 undefined 반환. */
+export function getConsultationHospitalDetailHref(hospitalId?: string): string | undefined {
+  if (!hospitalId || hospitalId === K_DOC_HOSPITAL_ID) {
+    return undefined;
+  }
+  return `/v2/hospital/${hospitalId}`;
+}

--- a/features/consultation-chat/lib/index.ts
+++ b/features/consultation-chat/lib/index.ts
@@ -1,2 +1,3 @@
 export { analyzeMessageContent } from './message-content-handler';
 export type { MessageContentAnalysis } from './message-content-handler';
+export { getConsultationHospitalDetailHref } from './consultation-hospital-link';

--- a/features/consultation-chat/ui/ConsultationChatMainV2.tsx
+++ b/features/consultation-chat/ui/ConsultationChatMainV2.tsx
@@ -6,6 +6,7 @@ import { PageHeaderV2 } from 'shared/ui/page-header/PageHeaderV2';
 import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
 import { type ChatMessage } from '../api/entities/types';
+import { getConsultationHospitalDetailHref } from '../lib/consultation-hospital-link';
 
 interface ConsultationChatMainV2Props {
   lang: Locale;
@@ -38,7 +39,7 @@ export function ConsultationChatMainV2({
     <div className='flex h-screen flex-col bg-white'>
       <PageHeaderV2
         title={hospitalName}
-        titleHref={`/v2/hospital/${hospitalId}`}
+        titleHref={getConsultationHospitalDetailHref(hospitalId)}
         fallbackUrl={`/${lang}/consultation`}
         closeUrl='/'
       />

--- a/features/consultation-chat/ui/HospitalMessage.tsx
+++ b/features/consultation-chat/ui/HospitalMessage.tsx
@@ -5,6 +5,7 @@ import { type Dictionary } from 'shared/model/types';
 import { type ChatMessage } from '../api/entities/types';
 import { formatMessageTime } from '../lib/chat-utils';
 import { analyzeMessageContent } from '../lib/message-content-handler';
+import { getConsultationHospitalDetailHref } from '../lib/consultation-hospital-link';
 import { HospitalPictureMessage } from './HospitalPictureMessage';
 import { HospitalEditorMessage } from './HospitalEditorMessage';
 import { HospitalTextMessage } from './HospitalTextMessage';
@@ -29,7 +30,7 @@ export function HospitalMessage({
   dict,
 }: HospitalMessageProps) {
   const formattedTime = formatMessageTime(message.timestamp);
-  const hospitalHref = hospitalId ? `/v2/hospital/${hospitalId}` : undefined;
+  const hospitalHref = getConsultationHospitalDetailHref(hospitalId);
 
   // returnUrl을 현재 URL의 경로로 설정 (pathname만)
   const returnUrl = typeof window !== 'undefined' ? window.location.pathname : undefined;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1093,13 +1093,13 @@ model HospitalCurationList {
   sortType              String
   createdAt             DateTime                @default(now())
   updatedAt             DateTime
+  placement             String?
   HospitalCurationEntry HospitalCurationEntry[]
 
   @@unique([category, sortType])
   @@index([category, sortType])
   @@schema("public")
 }
-
 
 enum AdminGrade {
   STAFF

--- a/shared/config/hospital-constants.ts
+++ b/shared/config/hospital-constants.ts
@@ -4,3 +4,6 @@
 
 // 압구정 미라클 의원 ID
 export const APGUJEONG_MIRACLE_HOSPITAL_ID = 'ffda0620-c254-44db-8b13-ef4ef5d368e5';
+
+// K-DOC 공식 상담 병원 ID — 상담채팅에서 병원상세 이동 예외 처리용
+export const K_DOC_HOSPITAL_ID = '9f0b2e9a-4c3d-4f1f-9a0e-6f8a7b1c2d34';


### PR DESCRIPTION
## Summary

- K-DOC 상담 챗봇(kdoc-chat) UI/플로우 전면 개편: 메인 메뉴, FAQ, 게스트 정보 입력, 국적 선택 드로어, 운영시간 기반 자동응답, 상담 이력 페이지 추가
- 상담 채팅 UX 개선: GNB 햄버거 메뉴, 스레드 자동 로드/생성, 메시지 버블·캐러셀 렌더링, K-DOC 병원 로고 클릭 시 병원상세 이동 예외 처리
- 병원 목록 API(`getHospitalsV2`) 카테고리 필터 로직 수정: RECOMMEND 탭은 추천 카테고리 할당 기준, 부위 탭은 `MedicalSpecialty.specialtyType` 기준

## Test plan

- [ ] `/kdoc-chat` 신규 문의 → 메인 메뉴/FAQ/상담신청/게스트 폼 플로우 확인
- [ ] 게스트/로그인 사용자 모두 상담 이력 페이지(`/kdoc-consultation-history`) 목록·스레드 이동 확인
- [ ] 운영시간 외 자동응답 메시지 발송 확인
- [ ] K-DOC 병원(`9f0b2e9a-...`) 상담채팅에서 로고/헤더 클릭 시 병원상세 미이동 확인
- [ ] 다른 병원 상담채팅에서는 로고 클릭 시 병원상세 이동 확인
- [ ] 병원 목록 RECOMMEND/부위 탭 필터·정렬 정상 동작 확인


Made with [Cursor](https://cursor.com)