### PR TITLE
fix(hospital-api): 최신순·리뷰많은순을 큐레이션 비의존 정렬로 복원

### DIFF
--- a/entities/hospital/api/use-cases/get-hospitals-v2.ts
+++ b/entities/hospital/api/use-cases/get-hospitals-v2.ts
@@ -192,6 +192,18 @@ async function fetchSortedHospitalPage(params: {
       ? Prisma.sql`AND h."districtId" = ANY(${districtIds}::uuid[])`
       : Prisma.empty;
 
+  // ── 정렬 기준 ──────────────────────────────────────────────────────────────
+  //  - 인기순(POPULAR): 큐레이션 position 기준 (admin 수동 정렬)
+  //  - 최신순(NEWEST): 병원 등록일 내림차순
+  //  - 리뷰많은순(RECOMMENDED): 리뷰 수 내림차순
+  // (멤버십은 LEFT JOIN + 할당 필터라 큐레이션 등록 여부와 무관하게 모두 노출됨)
+  const orderClause =
+    adminSortType === 'NEWEST'
+      ? Prisma.sql`ORDER BY h."createdAt" DESC, h.id ASC`
+      : adminSortType === 'RECOMMENDED'
+        ? Prisma.sql`ORDER BY (SELECT COUNT(*) FROM "Review" r WHERE r."hospitalId" = h.id) DESC, h.id ASC`
+        : Prisma.sql`ORDER BY e.position ASC NULLS LAST, h.rating DESC`;
+
   const [countResult, rows] = await Promise.all([
     prisma.$queryRaw<[{ count: bigint }]>`
       SELECT COUNT(*) AS count
@@ -212,7 +224,7 @@ async function fetchSortedHospitalPage(params: {
       ${recommendFilter}
       ${specialtyFilter}
       ${districtFilter}
-      ORDER BY e.position ASC NULLS LAST, h.rating DESC
+      ${orderClause}
       LIMIT  ${limit}
       OFFSET ${offset}
     `,


### PR DESCRIPTION
## 개요
병원 리스트 페이지에서 **최신순/리뷰많은순** 정렬이 큐레이션 `position`을 따르고 있던 문제를 수정합니다. 큐레이션 기반 정렬은 **인기순(POPULAR)에만** 적용되어야 하고, 나머지는 원래 데이터 기준으로 정렬되어야 합니다.

## 변경 내용
`get-hospitals-v2.ts`의 `fetchSortedHospitalPage` ORDER BY를 `sortType`별로 분기:

- **인기순(POPULAR)**: 큐레이션 `position` 기준 (admin 수동 정렬) — 기존 유지
- **최신순(NEWEST)**: 병원 등록일(`createdAt`) 내림차순
- **리뷰많은순(RECOMMENDED)**: 리뷰 수 내림차순

멤버십(할당 필터)과 배지 로직은 변경하지 않았습니다. 기존 `LEFT JOIN + 할당 필터` 구조라 큐레이션 등록 여부와 무관하게 해당 카테고리 병원이 모두 노출됩니다.

## 검증
- 타입 체크 통과
- 로컬 API 확인: LIFTING 기준
  - 인기순 → position 순
  - 최신순 → 등록일 최신순 (신규 병원 상단)
  - 리뷰많은순 → 리뷰 수 65→50→45→33… 순

🤖 Generated with [Claude Code](https://claude.com/claude-code)